### PR TITLE
Enabled symengine in gems.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ matrix:
     - rvm: ruby-head
 
 before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
-  - sudo apt-get install -qq gnuplot-nox libgsl0-dev libsqlite3-dev libatlas-base-dev libmagickcore-dev
+  - sudo apt-get install -qq gnuplot-nox libgsl0-dev libsqlite3-dev libatlas-base-dev libmagickcore-dev cmake libgmp-dev g++-4.7
   - sudo ln -s /usr/lib/libtoolize /usr/lib/libtool
+  - source scripts/install_symengine.sh
 
 env:
   global:

--- a/gems.yml
+++ b/gems.yml
@@ -399,8 +399,8 @@ symbolic:
 symengine:
   category: algebra
   description: Symbolic math
-  exclude: Gem is broken
   module: SymEngine
+  version: '~> 0.0'
 tioga:
   category: plotting
   description: Scientific plots with PDF and TeX

--- a/scripts/install_symengine.sh
+++ b/scripts/install_symengine.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Clone SymEngine and checkout to the commit symengine.rb was tested with
+export LAST_DIR=`pwd`
+git clone https://github.com/symengine/symengine.git symengine-cpp
+cd symengine-cpp
+wget https://raw.githubusercontent.com/symengine/symengine.rb/master/symengine_version.txt
+git checkout `cat symengine_version.txt`
+
+# Build and install SymEngine
+mkdir build && cd build
+export CXX=g++-4.7
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=no ..
+sudo make -j8 install
+cd $LAST_DIR
+rm -rf symengine-cpp
+
+


### PR DESCRIPTION
[symengine.rb](https://github.com/symengine/symengine.rb) is available on rubygems.org as a gem and can be installed by `gem install symengine`. This is required for https://github.com/SciRuby/sciruby-notebooks/pull/3

cc @v0dro 